### PR TITLE
Fix Base32 padding for partial chunks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1191,7 +1191,8 @@
                 }
                 
                 for (let j = 0; j < 8; j++) {
-                    if (i === bytes.length - 1 && j >= Math.ceil(chunk.length * 8 / 5)) {
+                    if (j >= Math.ceil(chunk.length * 8 / 5)) {
+                        // 對於不足 5 位元組的最後一塊，需要補 '=' 做為填充
                         result += '=';
                     } else {
                         const index = (value >>> (35 - j * 5)) & 0x1F;


### PR DESCRIPTION
## Summary
- fix Base32 encoding to properly pad incomplete byte chunks

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE'
const fs=require('fs');
const content=fs.readFileSync('index.html','utf-8');
const alphabet=content.match(/const BASE32_ALPHABET = '([A-Z2-7]+)'/)[1];
function arrayBufferToBase32(buffer){
  const BASE32_ALPHABET = alphabet;
  const bytes = new Uint8Array(buffer);
  let result='';
  for(let i=0;i<bytes.length;i+=5){
    const chunk=bytes.slice(i,i+5);
    let value=0;
    for(let j=0;j<chunk.length;j++){ value=(value<<8)|chunk[j]; }
    const padding=5 - chunk.length;
    if(padding>0){ value <<= padding*8; }
    for(let j=0;j<8;j++){
      if(j >= Math.ceil(chunk.length *8 /5)){
        result+='=';
      } else {
        const index=(value >>> (35 - j*5)) & 0x1F;
        result+=BASE32_ALPHABET[index];
      }
    }
  }
  return result;
}
const data=new TextEncoder().encode('1234567');
console.log(arrayBufferToBase32(data.buffer));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6892ebfba02083319025754464f196b8