### PR TITLE
Fix auto-decompression for non-gzip data

### DIFF
--- a/index.html
+++ b/index.html
@@ -1741,7 +1741,8 @@
                 }
 
                 const uint8 = new Uint8Array(arrayBuffer);
-                if (autoDecompress || (uint8[0] === 0x1f && uint8[1] === 0x8b)) {
+                const isGzip = uint8[0] === 0x1f && uint8[1] === 0x8b;
+                if (autoDecompress && isGzip) {
                     showStatus('decodeStatus', '🔓 正在解碼並解壓...', 'info');
                     progressFill.style.width = '50%';
                     progressText.textContent = '正在解壓縮...';
@@ -1751,6 +1752,8 @@
                     } catch (e) {
                         throw new Error('解壓縮失敗：' + e.message);
                     }
+                } else if (autoDecompress && !isGzip) {
+                    showToast('資料非 gzip 壓縮，跳過解壓', 'warning');
                 }
 
                 progressFill.style.width = '75%';


### PR DESCRIPTION
## Summary
- Only attempt gzip decompression when both auto-decompress is enabled and magic bytes match
- Warn user when auto-decompression is requested but data isn't gzip

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node` script verifying non-gzip data skips decompression and gzip data decompresses correctly


------
https://chatgpt.com/codex/tasks/task_e_689463048e0483318966b3c9f22169b1