### PR TITLE
Optimize hex encoding with lookup table

### DIFF
--- a/index.html
+++ b/index.html
@@ -1517,6 +1517,9 @@
                 let encodedString = '';
                 let base64Carry = new Uint8Array(0);
                 let base32Carry = new Uint8Array(0);
+                const hexTable = Array.from({ length: 256 }, (_, i) =>
+                    i.toString(16).padStart(2, '0')
+                );
 
                 for await (const chunk of FileProcessor.processInChunks(
                     file,
@@ -1539,7 +1542,9 @@
                             break;
                         }
                         case 'hex':
-                            encodedString += Array.from(dataChunk, byte => byte.toString(16).padStart(2, '0')).join('');
+                            for (let i = 0; i < dataChunk.length; i++) {
+                                encodedString += hexTable[dataChunk[i]];
+                            }
                             break;
                         case 'base32': {
                             const res = encodeBase32Chunk(dataChunk, base32Carry);


### PR DESCRIPTION
## Summary
- Precompute 256-element hex lookup table outside processing loop
- Replace Array.from hex conversion with for-loop using lookup table

## Testing
- `node - <<'NODE'` (compare new hex encoding with old implementation)
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894630e73e88331825992b9d2b419a5