### PR TITLE
Use DOM nodes for status messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -2254,18 +2254,29 @@
                 info: 'ℹ️',
                 warning: '⚠️'
             };
-            
-            statusElement.innerHTML = `
-                <div class="status-message status-${type}">
-                    ${iconMap[type] || ''} ${message}
-                </div>
-            `;
-            
+            statusElement.textContent = '';
+
+            const wrapper = document.createElement('div');
+            wrapper.className = `status-message status-${type}`;
+
+            if (iconMap[type]) {
+                const iconSpan = document.createElement('span');
+                iconSpan.textContent = iconMap[type];
+                wrapper.appendChild(iconSpan);
+                wrapper.appendChild(document.createTextNode(' '));
+            }
+
+            const messageSpan = document.createElement('span');
+            messageSpan.textContent = message;
+            wrapper.appendChild(messageSpan);
+
+            statusElement.appendChild(wrapper);
+
             // 自動清除成功和錯誤訊息
             if (type === 'success' || type === 'error') {
                 setTimeout(() => {
-                    if (statusElement.innerHTML.includes(message)) {
-                        statusElement.innerHTML = '';
+                    if (statusElement.contains(wrapper)) {
+                        statusElement.textContent = '';
                     }
                 }, 5000);
             }


### PR DESCRIPTION
## Summary
- Render status messages using DOM APIs instead of `innerHTML` for safer output.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689595d1dee48331857ff5f296986d9d